### PR TITLE
Add Flask web app for chapter-based TTS conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ Aplicación web en Flask que convierte libros en formatos **TXT**, **DOCX** o **
 - Dependencias de `requirements.txt`
 
 ## Uso
-1. Instala dependencias: `pip install -r requirements.txt`.
-2. Ejecuta la aplicación: `python app.py`.
-3. Abre `http://localhost:5000` y sube un archivo.
-4. Elige idioma, género, velocidad y carpeta de salida.
-5. Se generará un MP3 por capítulo en la carpeta indicada.
+1. (Opcional) Crea un entorno virtual: `python -m venv .venv && source .venv/bin/activate`.
+2. Instala dependencias: `pip install -r requirements.txt`.
+3. Ejecuta la aplicación: `python app.py`.
+4. Abre `http://localhost:5000` y sube un archivo.
+5. Elige idioma, género, velocidad y carpeta de salida.
+6. Se generará un MP3 por capítulo en la carpeta indicada.
 
 El sistema detecta capítulos mediante encabezados como "Capítulo X" o "Chapter X". Cada capítulo se procesa en bloques de 200 líneas con una pausa de un segundo entre peticiones para evitar límites del servicio. Durante la conversión se muestra una barra de progreso estimada basada en el tamaño del archivo.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # TTS-converte-Pro
+
+Aplicación web en Flask que convierte libros en formatos **TXT**, **DOCX** o **DOC** a archivos de audio **MP3**, generando un archivo por capítulo mediante voces de **Microsoft Edge TTS**.
+
+## Requisitos
+- Python 3.10+
+- ffmpeg instalado
+- Dependencias de `requirements.txt`
+
+## Uso
+1. Instala dependencias: `pip install -r requirements.txt`.
+2. Ejecuta la aplicación: `python app.py`.
+3. Abre `http://localhost:5000` y sube un archivo.
+4. Elige idioma, género, velocidad y carpeta de salida.
+5. Se generará un MP3 por capítulo en la carpeta indicada.
+
+El sistema detecta capítulos mediante encabezados como "Capítulo X" o "Chapter X". Cada capítulo se procesa en bloques de 200 líneas con una pausa de un segundo entre peticiones para evitar límites del servicio. Durante la conversión se muestra una barra de progreso estimada basada en el tamaño del archivo.

--- a/app.py
+++ b/app.py
@@ -1,8 +1,14 @@
 import asyncio
 import os
 from pathlib import Path
-from flask import Flask, render_template, request
-from werkzeug.utils import secure_filename
+
+try:
+    from flask import Flask, render_template, request
+    from werkzeug.utils import secure_filename
+except ModuleNotFoundError as exc:  # pragma: no cover - helpful runtime hint
+    raise SystemExit(
+        "Flask no está instalado. Ejecuta 'pip install -r requirements.txt'"
+    ) from exc
 
 from tts import read_txt, read_docx, read_doc, synthesize_book
 

--- a/app.py
+++ b/app.py
@@ -1,0 +1,67 @@
+import asyncio
+import os
+from pathlib import Path
+from flask import Flask, render_template, request
+from werkzeug.utils import secure_filename
+
+from tts import read_txt, read_docx, read_doc, synthesize_book
+
+app = Flask(__name__)
+
+VOICE_MAP = {
+    "castellano": {
+        "femenina": "es-ES-ElviraNeural",
+        "masculina": "es-ES-AlvaroNeural",
+    },
+    "catalan": {
+        "femenina": "ca-ES-AlbaNeural",
+        "masculina": "ca-ES-EnricNeural",
+    },
+}
+
+SPEED_MAP = {"lenta": "-25%", "normal": "0%", "rapida": "+25%"}
+
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+
+@app.route("/convert", methods=["POST"])
+def convert():
+    file = request.files["archivo"]
+    idioma = request.form.get("idioma")
+    genero = request.form.get("genero")
+    velocidad = request.form.get("velocidad")
+    carpeta = request.form.get("carpeta") or "salida"
+
+    book_name = Path(file.filename).stem
+    filename = secure_filename(file.filename)
+    upload_path = os.path.join("uploads", filename)
+    os.makedirs("uploads", exist_ok=True)
+    file.save(upload_path)
+
+    if filename.lower().endswith(".txt"):
+        text = read_txt(upload_path)
+    elif filename.lower().endswith(".docx"):
+        text = read_docx(upload_path)
+    elif filename.lower().endswith(".doc"):
+        text = read_doc(upload_path)
+    else:
+        return "Formato no soportado", 400
+
+    voice = VOICE_MAP.get(idioma, VOICE_MAP["castellano"])[genero]
+    rate = SPEED_MAP.get(velocidad, "0%")
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    files = loop.run_until_complete(
+        synthesize_book(text, voice, rate, carpeta, book_name)
+    )
+    loop.close()
+
+    return render_template("exito.html", archivos=files, carpeta=carpeta)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Flask>=2.2
+python-docx>=0.8
+edge-tts>=6.1
+pydub>=0.25
+textract>=1.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask>=2.2
+Flask>=2.0
 python-docx>=0.8
 edge-tts>=6.1
 pydub>=0.25

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,32 @@
+body {
+  font-family: Arial, sans-serif;
+  text-align: center;
+  margin: 40px;
+}
+
+form {
+  margin: 0 auto;
+  width: 300px;
+}
+
+button {
+  padding: 10px 20px;
+  margin-top: 10px;
+}
+
+#progress-container {
+  width: 100%;
+  background: #eee;
+  height: 20px;
+  margin-top: 20px;
+}
+
+#progress-bar {
+  height: 100%;
+  width: 0;
+  background: #4caf50;
+}
+
+.hidden {
+  display: none;
+}

--- a/templates/exito.html
+++ b/templates/exito.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <title>Conversión exitosa</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+</head>
+<body>
+  <h1>Conversión finalizada</h1>
+  <p>Archivos guardados en {{ carpeta }}</p>
+  <ul>
+  {% for archivo in archivos %}
+    <li>{{ archivo }}</li>
+  {% endfor %}
+  </ul>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <title>Conversor TTS</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+</head>
+<body>
+  <h1>Conversor TTS</h1>
+  <form id="convert-form" enctype="multipart/form-data">
+    <input type="file" name="archivo" required><br>
+    <label>Idioma:</label>
+    <select name="idioma">
+      <option value="castellano">Castellano</option>
+      <option value="catalan">Catalán</option>
+    </select><br>
+    <label>Género:</label>
+    <select name="genero">
+      <option value="femenina">Femenina</option>
+      <option value="masculina">Masculina</option>
+    </select><br>
+    <label>Velocidad:</label>
+    <select name="velocidad">
+      <option value="lenta">Lenta</option>
+      <option value="normal" selected>Normal</option>
+      <option value="rapida">Rápida</option>
+    </select><br>
+    <label>Carpeta de salida:</label>
+    <input type="text" name="carpeta" placeholder="salida"><br>
+    <button type="submit">Convertir</button>
+  </form>
+  <div id="progress-container" class="hidden">
+    <div id="progress-bar"></div>
+  </div>
+  <script>
+  const form = document.getElementById('convert-form');
+  form.addEventListener('submit', async (e)=>{
+    e.preventDefault();
+    const data = new FormData(form);
+    const file = form.querySelector('input[type=file]').files[0];
+    const est = Math.max(5, file.size / 50000); // segundos estimados
+    const bar = document.getElementById('progress-bar');
+    const container = document.getElementById('progress-container');
+    container.classList.remove('hidden');
+    let start = Date.now();
+    const duration = est * 1000;
+    function animate(){
+      const now = Date.now();
+      const pct = Math.min(100, ((now-start)/duration)*100);
+      bar.style.width = pct + '%';
+      if(pct < 100){ requestAnimationFrame(animate); }
+    }
+    animate();
+    const resp = await fetch('/convert', {method:'POST', body:data});
+    const html = await resp.text();
+    document.open();
+    document.write(html);
+    document.close();
+  });
+  </script>
+</body>
+</html>

--- a/tts.py
+++ b/tts.py
@@ -1,0 +1,69 @@
+import asyncio
+import os
+import re
+from typing import List, Tuple
+
+import edge_tts
+from docx import Document
+from pydub import AudioSegment
+import textract
+
+CHUNK_LINES = 200
+CHUNK_DELAY = 1
+
+
+def read_txt(path: str) -> str:
+    with open(path, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def read_docx(path: str) -> str:
+    doc = Document(path)
+    return "\n".join(p.text for p in doc.paragraphs)
+
+
+def read_doc(path: str) -> str:
+    text = textract.process(path)
+    return text.decode("utf-8")
+
+
+def split_into_chapters(text: str) -> List[Tuple[str, str]]:
+    pattern = re.compile(r"^(?:Cap[ií]tulo|Chapter)\s+\d+", re.IGNORECASE | re.MULTILINE)
+    matches = list(pattern.finditer(text))
+    if not matches:
+        return [("capitulo_1", text)]
+    chapters = []
+    for i, match in enumerate(matches):
+        start = match.start()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        chapter_text = text[start:end].strip()
+        chapters.append((f"capitulo_{i + 1}", chapter_text))
+    return chapters
+
+
+async def synthesize(text: str, voice: str, rate: str, output_path: str) -> None:
+    lines = text.splitlines()
+    chunks = ["\n".join(lines[i : i + CHUNK_LINES]) for i in range(0, len(lines), CHUNK_LINES)]
+    temp_files = []
+    for idx, chunk in enumerate(chunks):
+        communicate = edge_tts.Communicate(chunk, voice=voice, rate=rate)
+        tmp_file = f"{output_path}_tmp_{idx}.mp3"
+        await communicate.save(tmp_file)
+        temp_files.append(tmp_file)
+        await asyncio.sleep(CHUNK_DELAY)
+    audio = AudioSegment.empty()
+    for f in temp_files:
+        audio += AudioSegment.from_file(f)
+        os.remove(f)
+    audio.export(output_path, format="mp3")
+
+
+async def synthesize_book(text: str, voice: str, rate: str, out_dir: str, book_name: str) -> List[str]:
+    os.makedirs(out_dir, exist_ok=True)
+    chapters = split_into_chapters(text)
+    files = []
+    for i, (_, chapter_text) in enumerate(chapters, start=1):
+        filename = os.path.join(out_dir, f"{book_name}_capitulo_{i}.mp3")
+        await synthesize(chapter_text, voice, rate, filename)
+        files.append(filename)
+    return files


### PR DESCRIPTION
## Summary
- Implement Flask service to convert uploaded TXT/DOCX/DOC files into MP3 chapters using Microsoft Edge TTS
- Add asynchronous synthesis utilities with chapter detection and chunked processing
- Provide web interface with voice, language, speed options and a client-side progress bar

## Testing
- `python -m py_compile app.py tts.py`


------
https://chatgpt.com/codex/tasks/task_e_689b4e30ba1883268011b7d42b91935c