### PR TITLE
Expose chunk configuration in web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Aplicación web en Flask que convierte libros en formatos **TXT**, **DOCX** o **
 1. Instala dependencias: `pip install -r requirements.txt`.
 2. Ejecuta la aplicación: `python app.py`.
 3. Abre `http://localhost:5000` y sube un archivo.
-4. Elige idioma, género, velocidad y carpeta de salida.
+4. Elige idioma, género, velocidad, número de líneas por bloque, pausa entre bloques y carpeta de salida.
 5. Se generará un MP3 por capítulo en la carpeta indicada.
 
-El sistema detecta capítulos mediante encabezados como "Capítulo X" o "Chapter X". Cada capítulo se procesa en bloques de 200 líneas con una pausa de un segundo entre peticiones para evitar límites del servicio. Durante la conversión se muestra una barra de progreso estimada basada en el tamaño del archivo.
+El sistema detecta capítulos mediante encabezados como "Capítulo X" o "Chapter X". Cada capítulo se procesa en bloques de líneas configurables con una pausa entre peticiones para evitar límites del servicio. Durante la conversión se muestra una barra de progreso estimada basada en el tamaño del archivo.

--- a/app.py
+++ b/app.py
@@ -4,7 +4,14 @@ from pathlib import Path
 from flask import Flask, render_template, request
 from werkzeug.utils import secure_filename
 
-from tts import read_txt, read_docx, read_doc, synthesize_book
+from tts import (
+    DEFAULT_CHUNK_DELAY,
+    DEFAULT_CHUNK_LINES,
+    read_doc,
+    read_docx,
+    read_txt,
+    synthesize_book,
+)
 
 app = Flask(__name__)
 
@@ -34,6 +41,8 @@ def convert():
     genero = request.form.get("genero")
     velocidad = request.form.get("velocidad")
     carpeta = request.form.get("carpeta") or "salida"
+    lineas = request.form.get("lineas", type=int) or DEFAULT_CHUNK_LINES
+    pausa = request.form.get("pausa", type=float) or DEFAULT_CHUNK_DELAY
 
     book_name = Path(file.filename).stem
     filename = secure_filename(file.filename)
@@ -56,7 +65,15 @@ def convert():
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     files = loop.run_until_complete(
-        synthesize_book(text, voice, rate, carpeta, book_name)
+        synthesize_book(
+            text,
+            voice,
+            rate,
+            carpeta,
+            book_name,
+            chunk_lines=lineas,
+            chunk_delay=pausa,
+        )
     )
     loop.close()
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -25,6 +25,10 @@
       <option value="normal" selected>Normal</option>
       <option value="rapida">Rápida</option>
     </select><br>
+    <label>Líneas por bloque:</label>
+    <input type="number" name="lineas" value="200" min="1"><br>
+    <label>Pausa entre bloques (s):</label>
+    <input type="number" step="0.1" name="pausa" value="1"><br>
     <label>Carpeta de salida:</label>
     <input type="text" name="carpeta" placeholder="salida"><br>
     <button type="submit">Convertir</button>

--- a/tts.py
+++ b/tts.py
@@ -8,8 +8,9 @@ from docx import Document
 from pydub import AudioSegment
 import textract
 
-CHUNK_LINES = 200
-CHUNK_DELAY = 1
+
+DEFAULT_CHUNK_LINES = 200
+DEFAULT_CHUNK_DELAY = 1
 
 
 def read_txt(path: str) -> str:
@@ -41,16 +42,26 @@ def split_into_chapters(text: str) -> List[Tuple[str, str]]:
     return chapters
 
 
-async def synthesize(text: str, voice: str, rate: str, output_path: str) -> None:
+async def synthesize(
+    text: str,
+    voice: str,
+    rate: str,
+    output_path: str,
+    chunk_lines: int = DEFAULT_CHUNK_LINES,
+    chunk_delay: float = DEFAULT_CHUNK_DELAY,
+) -> None:
     lines = text.splitlines()
-    chunks = ["\n".join(lines[i : i + CHUNK_LINES]) for i in range(0, len(lines), CHUNK_LINES)]
+    chunks = [
+        "\n".join(lines[i : i + chunk_lines])
+        for i in range(0, len(lines), chunk_lines)
+    ]
     temp_files = []
     for idx, chunk in enumerate(chunks):
         communicate = edge_tts.Communicate(chunk, voice=voice, rate=rate)
         tmp_file = f"{output_path}_tmp_{idx}.mp3"
         await communicate.save(tmp_file)
         temp_files.append(tmp_file)
-        await asyncio.sleep(CHUNK_DELAY)
+        await asyncio.sleep(chunk_delay)
     audio = AudioSegment.empty()
     for f in temp_files:
         audio += AudioSegment.from_file(f)
@@ -58,12 +69,27 @@ async def synthesize(text: str, voice: str, rate: str, output_path: str) -> None
     audio.export(output_path, format="mp3")
 
 
-async def synthesize_book(text: str, voice: str, rate: str, out_dir: str, book_name: str) -> List[str]:
+async def synthesize_book(
+    text: str,
+    voice: str,
+    rate: str,
+    out_dir: str,
+    book_name: str,
+    chunk_lines: int = DEFAULT_CHUNK_LINES,
+    chunk_delay: float = DEFAULT_CHUNK_DELAY,
+) -> List[str]:
     os.makedirs(out_dir, exist_ok=True)
     chapters = split_into_chapters(text)
     files = []
     for i, (_, chapter_text) in enumerate(chapters, start=1):
         filename = os.path.join(out_dir, f"{book_name}_capitulo_{i}.mp3")
-        await synthesize(chapter_text, voice, rate, filename)
+        await synthesize(
+            chapter_text,
+            voice,
+            rate,
+            filename,
+            chunk_lines=chunk_lines,
+            chunk_delay=chunk_delay,
+        )
         files.append(filename)
     return files


### PR DESCRIPTION
## Summary
- allow users to configure lines-per-block and delay through the web UI
- wire new options into Flask backend and TTS synthesis
- document customizable chunk size and delay

## Testing
- `python -m py_compile app.py tts.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask>=2.2)*

------
https://chatgpt.com/codex/tasks/task_e_689b9e527bc08326a64fa826181cb5eb