### PR TITLE
feat: enhance web UI with pitch control and scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Aplicación web en Flask que convierte libros en formatos **TXT**, **DOCX** o **
 - Dependencias de `requirements.txt`
 
 ## Uso
-1. Instala dependencias: `pip install -r requirements.txt`.
-2. Ejecuta la aplicación: `python app.py`.
+1. Inicio rápido: `./start.sh` instala dependencias y lanza la web.
+2. Para detenerla: `./stop.sh`.
 3. Abre `http://localhost:5000` y sube un archivo.
-4. Elige idioma, género, velocidad y carpeta de salida.
+4. Configura idioma, género, velocidad, **pitch** (control deslizante), número de líneas por bloque, pausa entre bloques y carpeta de salida (seleccionable).
 5. Se generará un MP3 por capítulo en la carpeta indicada.
 
-El sistema detecta capítulos mediante encabezados como "Capítulo X" o "Chapter X". Cada capítulo se procesa en bloques de 200 líneas con una pausa de un segundo entre peticiones para evitar límites del servicio. Durante la conversión se muestra una barra de progreso estimada basada en el tamaño del archivo.
+El sistema detecta capítulos mediante encabezados como "Capítulo X" o "Chapter X". Cada capítulo se procesa en bloques de líneas configurables con una pausa entre peticiones (`REQUEST_PAUSE`) para evitar límites del servicio. Durante la conversión se muestra una barra de progreso estimada basada en el tamaño del archivo y una interfaz con estilo moderno.

--- a/app.py
+++ b/app.py
@@ -4,7 +4,14 @@ from pathlib import Path
 from flask import Flask, render_template, request
 from werkzeug.utils import secure_filename
 
-from tts import read_txt, read_docx, read_doc, synthesize_book
+from tts import (
+    DEFAULT_CHUNK_DELAY,
+    DEFAULT_CHUNK_LINES,
+    read_doc,
+    read_docx,
+    read_txt,
+    synthesize_book,
+)
 
 app = Flask(__name__)
 
@@ -33,7 +40,11 @@ def convert():
     idioma = request.form.get("idioma")
     genero = request.form.get("genero")
     velocidad = request.form.get("velocidad")
+    pitch_val = request.form.get("pitch", type=int) or 0
+    pitch = f"{pitch_val:+d}%"
     carpeta = request.form.get("carpeta") or "salida"
+    lineas = request.form.get("lineas", type=int) or DEFAULT_CHUNK_LINES
+    pausa = request.form.get("pausa", type=float) or DEFAULT_CHUNK_DELAY
 
     book_name = Path(file.filename).stem
     filename = secure_filename(file.filename)
@@ -56,7 +67,16 @@ def convert():
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     files = loop.run_until_complete(
-        synthesize_book(text, voice, rate, carpeta, book_name)
+        synthesize_book(
+            text,
+            voice,
+            rate,
+            carpeta,
+            book_name,
+            chunk_lines=lineas,
+            chunk_delay=pausa,
+            pitch=pitch,
+        )
     )
     loop.close()
 

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+pip install -r requirements.txt
+python app.py &
+echo $! > app.pid

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,17 +1,71 @@
 body {
-  font-family: Arial, sans-serif;
+  font-family: 'Segoe UI', sans-serif;
+  background: linear-gradient(135deg, #6dd5fa, #ffffff);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  margin: 0;
+}
+
+.card {
+  background: #fff;
+  padding: 20px 30px;
+  border-radius: 10px;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.1);
+  width: 320px;
+}
+
+label {
+  display: block;
+  margin-top: 15px;
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+input[type=file],
+input[type=number],
+input[type=text],
+select {
+  width: 100%;
+  padding: 8px;
+  margin-top: 5px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+input[type=range] {
+  width: 100%;
+}
+
+button,
+.btn {
+  width: 100%;
+  padding: 10px;
+  margin-top: 15px;
+  background: #4caf50;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-block;
   text-align: center;
-  margin: 40px;
 }
 
-form {
-  margin: 0 auto;
-  width: 300px;
+button:hover,
+.btn:hover {
+  background: #45a049;
 }
 
-button {
-  padding: 10px 20px;
-  margin-top: 10px;
+.folder-picker {
+  display: flex;
+  gap: 5px;
+}
+
+.folder-picker input[type=text] {
+  flex: 1;
 }
 
 #progress-container {
@@ -19,6 +73,8 @@ button {
   background: #eee;
   height: 20px;
   margin-top: 20px;
+  border-radius: 10px;
+  overflow: hidden;
 }
 
 #progress-bar {
@@ -29,4 +85,9 @@ button {
 
 .hidden {
   display: none;
+}
+
+ul {
+  text-align: left;
+  padding-left: 20px;
 }

--- a/stop.sh
+++ b/stop.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+if [ -f app.pid ]; then
+  kill $(cat app.pid) && rm app.pid
+else
+  pkill -f app.py || true
+fi

--- a/templates/exito.html
+++ b/templates/exito.html
@@ -6,12 +6,15 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
 </head>
 <body>
-  <h1>Conversión finalizada</h1>
-  <p>Archivos guardados en {{ carpeta }}</p>
-  <ul>
-  {% for archivo in archivos %}
-    <li>{{ archivo }}</li>
-  {% endfor %}
-  </ul>
+  <div class="card">
+    <h1>Conversión finalizada</h1>
+    <p>Archivos guardados en {{ carpeta }}</p>
+    <ul>
+    {% for archivo in archivos %}
+      <li>{{ archivo }}</li>
+    {% endfor %}
+    </ul>
+    <a href="/" class="btn">Volver</a>
+  </div>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,34 +6,70 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
 </head>
 <body>
-  <h1>Conversor TTS</h1>
-  <form id="convert-form" enctype="multipart/form-data">
-    <input type="file" name="archivo" required><br>
-    <label>Idioma:</label>
-    <select name="idioma">
-      <option value="castellano">Castellano</option>
-      <option value="catalan">Catalán</option>
-    </select><br>
-    <label>Género:</label>
-    <select name="genero">
-      <option value="femenina">Femenina</option>
-      <option value="masculina">Masculina</option>
-    </select><br>
-    <label>Velocidad:</label>
-    <select name="velocidad">
-      <option value="lenta">Lenta</option>
-      <option value="normal" selected>Normal</option>
-      <option value="rapida">Rápida</option>
-    </select><br>
-    <label>Carpeta de salida:</label>
-    <input type="text" name="carpeta" placeholder="salida"><br>
-    <button type="submit">Convertir</button>
-  </form>
-  <div id="progress-container" class="hidden">
-    <div id="progress-bar"></div>
+  <div class="card">
+    <h1>Conversor TTS</h1>
+    <form id="convert-form" enctype="multipart/form-data">
+      <label>Archivo:
+        <input type="file" name="archivo" required>
+      </label>
+      <label>Idioma:
+        <select name="idioma">
+          <option value="castellano">Castellano</option>
+          <option value="catalan">Catalán</option>
+        </select>
+      </label>
+      <label>Género:
+        <select name="genero">
+          <option value="femenina">Femenina</option>
+          <option value="masculina">Masculina</option>
+        </select>
+      </label>
+      <label>Velocidad:
+        <select name="velocidad">
+          <option value="lenta">Lenta</option>
+          <option value="normal" selected>Normal</option>
+          <option value="rapida">Rápida</option>
+        </select>
+      </label>
+      <label>Pitch:
+        <input type="range" name="pitch" id="pitch" min="-20" max="20" value="0">
+        <span id="pitch-val">0</span>
+      </label>
+      <label>Líneas por bloque:
+        <input type="number" name="lineas" value="200" min="1">
+      </label>
+      <label>Pausa entre bloques (s):
+        <input type="number" step="0.1" name="pausa" value="1">
+      </label>
+      <label>Carpeta de salida:</label>
+      <div class="folder-picker">
+        <input type="text" id="carpeta" name="carpeta" placeholder="salida" readonly>
+        <button type="button" id="carpetaBtn">Elegir</button>
+        <input type="file" id="carpetaInput" webkitdirectory directory style="display:none">
+      </div>
+      <button type="submit" class="btn">Convertir</button>
+    </form>
+    <div id="progress-container" class="hidden">
+      <div id="progress-bar"></div>
+    </div>
   </div>
   <script>
   const form = document.getElementById('convert-form');
+  const pitch = document.getElementById('pitch');
+  const pitchVal = document.getElementById('pitch-val');
+  pitch.addEventListener('input', ()=>{ pitchVal.textContent = pitch.value; });
+
+  const carpetaBtn = document.getElementById('carpetaBtn');
+  const carpetaInput = document.getElementById('carpetaInput');
+  const carpetaText = document.getElementById('carpeta');
+  carpetaBtn.addEventListener('click', ()=>carpetaInput.click());
+  carpetaInput.addEventListener('change', (e)=>{
+    if(carpetaInput.files.length>0){
+      const path = carpetaInput.files[0].webkitRelativePath.split('/')[0];
+      carpetaText.value = path;
+    }
+  });
+
   form.addEventListener('submit', async (e)=>{
     e.preventDefault();
     const data = new FormData(form);

--- a/tts.py
+++ b/tts.py
@@ -8,8 +8,10 @@ from docx import Document
 from pydub import AudioSegment
 import textract
 
-CHUNK_LINES = 200
-CHUNK_DELAY = 1
+
+DEFAULT_CHUNK_LINES = 200
+# Pausa por defecto entre peticiones para no saturar los servidores
+DEFAULT_CHUNK_DELAY = float(os.getenv("REQUEST_PAUSE", "1"))
 
 
 def read_txt(path: str) -> str:
@@ -41,16 +43,27 @@ def split_into_chapters(text: str) -> List[Tuple[str, str]]:
     return chapters
 
 
-async def synthesize(text: str, voice: str, rate: str, output_path: str) -> None:
+async def synthesize(
+    text: str,
+    voice: str,
+    rate: str,
+    output_path: str,
+    chunk_lines: int = DEFAULT_CHUNK_LINES,
+    chunk_delay: float = DEFAULT_CHUNK_DELAY,
+    pitch: str = "0%",
+) -> None:
     lines = text.splitlines()
-    chunks = ["\n".join(lines[i : i + CHUNK_LINES]) for i in range(0, len(lines), CHUNK_LINES)]
+    chunks = [
+        "\n".join(lines[i : i + chunk_lines])
+        for i in range(0, len(lines), chunk_lines)
+    ]
     temp_files = []
     for idx, chunk in enumerate(chunks):
-        communicate = edge_tts.Communicate(chunk, voice=voice, rate=rate)
+        communicate = edge_tts.Communicate(chunk, voice=voice, rate=rate, pitch=pitch)
         tmp_file = f"{output_path}_tmp_{idx}.mp3"
         await communicate.save(tmp_file)
         temp_files.append(tmp_file)
-        await asyncio.sleep(CHUNK_DELAY)
+        await asyncio.sleep(chunk_delay)
     audio = AudioSegment.empty()
     for f in temp_files:
         audio += AudioSegment.from_file(f)
@@ -58,12 +71,29 @@ async def synthesize(text: str, voice: str, rate: str, output_path: str) -> None
     audio.export(output_path, format="mp3")
 
 
-async def synthesize_book(text: str, voice: str, rate: str, out_dir: str, book_name: str) -> List[str]:
+async def synthesize_book(
+    text: str,
+    voice: str,
+    rate: str,
+    out_dir: str,
+    book_name: str,
+    chunk_lines: int = DEFAULT_CHUNK_LINES,
+    chunk_delay: float = DEFAULT_CHUNK_DELAY,
+    pitch: str = "0%",
+) -> List[str]:
     os.makedirs(out_dir, exist_ok=True)
     chapters = split_into_chapters(text)
     files = []
     for i, (_, chapter_text) in enumerate(chapters, start=1):
         filename = os.path.join(out_dir, f"{book_name}_capitulo_{i}.mp3")
-        await synthesize(chapter_text, voice, rate, filename)
+        await synthesize(
+            chapter_text,
+            voice,
+            rate,
+            filename,
+            chunk_lines=chunk_lines,
+            chunk_delay=chunk_delay,
+            pitch=pitch,
+        )
         files.append(filename)
     return files


### PR DESCRIPTION
## Summary
- Revamp web interface with modern styling, pitch slider, and folder picker
- Add pitch support and configurable request pause in TTS synthesis
- Provide start/stop scripts and document quick-start usage

## Testing
- `python -m py_compile app.py tts.py`


------
https://chatgpt.com/codex/tasks/task_e_689b9e527bc08326a64fa826181cb5eb