### PR TITLE
feat: add countdown and full chapter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,48 @@
 # TTS-converte-Pro
 
-Aplicación web en Flask que convierte libros en formatos **TXT**, **DOCX** o **DOC** a archivos de audio **MP3**, generando un archivo por capítulo mediante voces de **Microsoft Edge TTS**.
+Aplicación web en Flask que convierte libros en formatos **TXT** o **DOCX** a archivos de audio **MP3** por capítulo usando voces de **Microsoft Edge TTS**. La interfaz minimalista (blanco/negro con toques rojos) muestra la versión actual y permite ajustar idioma, género, velocidad, *pitch*, número de líneas por bloque, pausa entre bloques y nombre base del archivo. Los MP3 se guardan en `uploads/` usando el mismo nombre del proyecto y, durante la conversión, un panel de log muestra el progreso y las cuentas atrás entre bloques. Versión actual: **1.4.0**.
 
 ## Requisitos
 - Python 3.10+
-- ffmpeg instalado
+- `ffmpeg` instalado
 - Dependencias de `requirements.txt`
 
-## Uso
-1. Instala dependencias: `pip install -r requirements.txt`.
-2. Ejecuta la aplicación: `python app.py`.
-3. Abre `http://localhost:5000` y sube un archivo.
-4. Elige idioma, género, velocidad y carpeta de salida.
-5. Se generará un MP3 por capítulo en la carpeta indicada.
+## Descarga
+### Linux / macOS
+1. `git clone https://github.com/tuusuario/TTS-converte-Pro.git`
+2. `cd TTS-converte-Pro`
 
-El sistema detecta capítulos mediante encabezados como "Capítulo X" o "Chapter X". Cada capítulo se procesa en bloques de 200 líneas con una pausa de un segundo entre peticiones para evitar límites del servicio. Durante la conversión se muestra una barra de progreso estimada basada en el tamaño del archivo.
+### Windows
+1. Instala [Git](https://git-scm.com/download/win) y abre **Git Bash**.
+2. Ejecuta:
+   ```bash
+   git clone https://github.com/tuusuario/TTS-converte-Pro.git
+   cd TTS-converte-Pro
+   ```
+
+## Instalación
+### Linux / macOS
+1. *(Opcional)* `python -m venv .venv && source .venv/bin/activate`
+2. `pip install -r requirements.txt`
+
+### Windows
+1. *(Opcional)* `py -m venv .venv && .venv\Scripts\activate`
+2. `pip install -r requirements.txt`
+
+## Uso
+### Con scripts
+1. `./start.sh` instala dependencias y lanza la web.
+2. Abre `http://localhost:5000` y sube un archivo.
+3. `./stop.sh` detiene la aplicación.
+
+### Manual
+1. `python app.py`
+2. Abre `http://localhost:5000`.
+
+En la web puedes:
+- Elegir idioma, género y velocidad.
+- Ajustar *pitch*, líneas por bloque y pausa entre bloques (0 procesa el capítulo completo de una sola vez).
+- Definir el nombre base del archivo MP3.
+- Consultar la versión actual en la parte inferior de la página.
+
+Se generará un MP3 por capítulo en la carpeta `uploads/`, nombrando los archivos con el nombre del proyecto. Los capítulos se detectan mediante encabezados como "Capítulo X" o "Chapter X". Cada capítulo se procesa en bloques con una pausa (`REQUEST_PAUSE`) entre peticiones para evitar saturar el servicio. Durante la conversión se muestra una barra de progreso y, en el panel derecho, un log con el estado de cada capítulo y la cuenta atrás antes de reanudar.

--- a/app.py
+++ b/app.py
@@ -1,11 +1,20 @@
 import asyncio
 import os
 from pathlib import Path
-from flask import Flask, render_template, request
+import time
+from flask import Flask, Response, render_template, request
 from werkzeug.utils import secure_filename
 
-from tts import read_txt, read_docx, read_doc, synthesize_book
+from tts import (
+    DEFAULT_CHUNK_DELAY,
+    DEFAULT_CHUNK_LINES,
+    read_docx,
+    read_txt,
+    synthesize_book,
+)
 
+APP_VERSION = "1.4.0"
+__version__ = APP_VERSION
 app = Flask(__name__)
 
 VOICE_MAP = {
@@ -19,48 +28,83 @@ VOICE_MAP = {
     },
 }
 
-SPEED_MAP = {"lenta": "-25%", "normal": "0%", "rapida": "+25%"}
+SPEED_MAP = {"lenta": "-25%", "normal": "+0%", "rapida": "+25%"}
+
+LOG: list[str] = []
+
+
+def add_log(msg: str) -> None:
+    LOG.append(msg)
 
 
 @app.route("/")
 def index():
-    return render_template("index.html")
+    return render_template("index.html", version=APP_VERSION)
 
 
 @app.route("/convert", methods=["POST"])
 def convert():
+    LOG.clear()
+    add_log("Inicio de conversión")
     file = request.files["archivo"]
     idioma = request.form.get("idioma")
     genero = request.form.get("genero")
     velocidad = request.form.get("velocidad")
-    carpeta = request.form.get("carpeta") or "salida"
-
-    book_name = Path(file.filename).stem
+    pitch_val = request.form.get("pitch", type=int) or 0
+    pitch = f"{pitch_val:+d}Hz"
+    lineas = request.form.get("lineas", type=int) or DEFAULT_CHUNK_LINES
+    pausa = request.form.get("pausa", type=float) or DEFAULT_CHUNK_DELAY
+    nombre = request.form.get("nombre") or Path(file.filename).stem
+    book_name = secure_filename(nombre)
     filename = secure_filename(file.filename)
-    upload_path = os.path.join("uploads", filename)
-    os.makedirs("uploads", exist_ok=True)
+    upload_dir = "uploads"
+    os.makedirs(upload_dir, exist_ok=True)
+    upload_path = os.path.join(upload_dir, filename)
     file.save(upload_path)
+    output_dir = upload_dir
 
     if filename.lower().endswith(".txt"):
         text = read_txt(upload_path)
     elif filename.lower().endswith(".docx"):
         text = read_docx(upload_path)
-    elif filename.lower().endswith(".doc"):
-        text = read_doc(upload_path)
     else:
         return "Formato no soportado", 400
 
     voice = VOICE_MAP.get(idioma, VOICE_MAP["castellano"])[genero]
-    rate = SPEED_MAP.get(velocidad, "0%")
+    rate = SPEED_MAP.get(velocidad, "+0%")
 
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     files = loop.run_until_complete(
-        synthesize_book(text, voice, rate, carpeta, book_name)
+        synthesize_book(
+            text,
+            voice,
+            rate,
+            output_dir,
+            book_name,
+            chunk_lines=lineas,
+            chunk_delay=pausa,
+            pitch=pitch,
+            log_callback=add_log,
+        )
     )
     loop.close()
 
-    return render_template("exito.html", archivos=files, carpeta=carpeta)
+    display_files = [os.path.basename(f) for f in files]
+    return render_template("exito.html", archivos=display_files, version=APP_VERSION)
+
+
+@app.route("/logs")
+def logs():
+    def stream():
+        last = 0
+        while True:
+            if last < len(LOG):
+                data = LOG[last]
+                last += 1
+                yield f"data: {data}\n\n"
+            time.sleep(0.5)
+    return Response(stream(), mimetype="text/event-stream")
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Flask>=2.2
 python-docx>=0.8
 edge-tts>=6.1
 pydub>=0.25
-textract>=1.6
+

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+pip install -r requirements.txt
+python app.py &
+echo $! > app.pid

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,17 +1,114 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap');
+
 body {
-  font-family: Arial, sans-serif;
+  font-family: 'Poppins', sans-serif;
+  background: #fff;
+  color: #000;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  margin: 0;
+}
+
+.main {
+  display: flex;
+  gap: 20px;
+  align-items: flex-start;
+}
+
+.card {
+  background: #fff;
+  padding: 30px 40px;
+  border-radius: 12px;
+  border: 1px solid #000;
+  width: 380px;
+}
+
+label {
+  display: block;
+  margin-top: 15px;
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+input[type=file],
+input[type=number],
+input[type=text],
+select {
+  width: 100%;
+  padding: 8px;
+  margin-top: 5px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+input[type=range] {
+  width: 100%;
+}
+
+input[type=range]::-webkit-slider-thumb {
+  appearance: none;
+  background: #e63946;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  cursor: pointer;
+  margin-top: -6px;
+}
+
+input[type=range]::-webkit-slider-runnable-track {
+  background: #ddd;
+  height: 4px;
+  border-radius: 4px;
+}
+
+input[type=range]::-moz-range-thumb {
+  background: #e63946;
+  border: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  cursor: pointer;
+}
+
+input[type=range]::-moz-range-track {
+  background: #ddd;
+  height: 4px;
+  border-radius: 4px;
+}
+
+button,
+.btn {
+  width: 100%;
+  padding: 12px;
+  margin-top: 20px;
+  background: #e63946;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-block;
   text-align: center;
-  margin: 40px;
+  transition: background 0.2s ease-in-out;
 }
 
-form {
-  margin: 0 auto;
+button:hover,
+.btn:hover {
+  background: #ba1b1d;
+}
+
+
+.log-panel {
   width: 300px;
-}
-
-button {
-  padding: 10px 20px;
-  margin-top: 10px;
+  height: 400px;
+  border: 1px solid #000;
+  border-radius: 12px;
+  padding: 15px;
+  overflow-y: auto;
+  background: #fff;
 }
 
 #progress-container {
@@ -19,14 +116,29 @@ button {
   background: #eee;
   height: 20px;
   margin-top: 20px;
+  border-radius: 10px;
+  overflow: hidden;
 }
 
 #progress-bar {
   height: 100%;
   width: 0;
-  background: #4caf50;
+  background: #e63946;
+  transition: width 0.2s;
 }
 
 .hidden {
   display: none;
+}
+
+ul {
+  text-align: left;
+  padding-left: 20px;
+}
+
+.version {
+  margin-top: 15px;
+  font-size: 0.8rem;
+  color: #e63946;
+  text-align: center;
 }

--- a/stop.sh
+++ b/stop.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+if [ -f app.pid ]; then
+  kill $(cat app.pid) && rm app.pid
+else
+  pkill -f app.py || true
+fi

--- a/templates/exito.html
+++ b/templates/exito.html
@@ -6,12 +6,16 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
 </head>
 <body>
-  <h1>Conversión finalizada</h1>
-  <p>Archivos guardados en {{ carpeta }}</p>
-  <ul>
-  {% for archivo in archivos %}
-    <li>{{ archivo }}</li>
-  {% endfor %}
-  </ul>
+  <div class="card">
+    <h1>Conversión finalizada</h1>
+    <p>Archivos generados:</p>
+    <ul>
+    {% for archivo in archivos %}
+      <li>{{ archivo }}</li>
+    {% endfor %}
+    </ul>
+    <a href="/" class="btn">Volver</a>
+  </div>
+  <footer class="version">v{{ version }}</footer>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,38 +6,79 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
 </head>
 <body>
-  <h1>Conversor TTS</h1>
-  <form id="convert-form" enctype="multipart/form-data">
-    <input type="file" name="archivo" required><br>
-    <label>Idioma:</label>
-    <select name="idioma">
-      <option value="castellano">Castellano</option>
-      <option value="catalan">Catalán</option>
-    </select><br>
-    <label>Género:</label>
-    <select name="genero">
-      <option value="femenina">Femenina</option>
-      <option value="masculina">Masculina</option>
-    </select><br>
-    <label>Velocidad:</label>
-    <select name="velocidad">
-      <option value="lenta">Lenta</option>
-      <option value="normal" selected>Normal</option>
-      <option value="rapida">Rápida</option>
-    </select><br>
-    <label>Carpeta de salida:</label>
-    <input type="text" name="carpeta" placeholder="salida"><br>
-    <button type="submit">Convertir</button>
-  </form>
-  <div id="progress-container" class="hidden">
-    <div id="progress-bar"></div>
+  <div class="main">
+    <div class="card">
+    <h1>Conversor TTS</h1>
+      <form id="convert-form" enctype="multipart/form-data">
+      <label>Archivo:
+        <input type="file" name="archivo" id="archivo" required>
+      </label>
+      <label>Nombre base de salida:
+        <input type="text" name="nombre" id="nombre" placeholder="MiAudiolibro">
+      </label>
+      <label>Idioma:
+        <select name="idioma">
+          <option value="castellano">Castellano</option>
+          <option value="catalan">Catalán</option>
+        </select>
+      </label>
+      <label>Género:
+        <select name="genero">
+          <option value="femenina">Femenina</option>
+          <option value="masculina">Masculina</option>
+        </select>
+      </label>
+      <label>Velocidad:
+        <select name="velocidad">
+          <option value="lenta">Lenta</option>
+          <option value="normal" selected>Normal</option>
+          <option value="rapida">Rápida</option>
+        </select>
+      </label>
+      <label>Pitch (Hz):
+        <input type="range" name="pitch" id="pitch" min="-20" max="20" value="0">
+        <span id="pitch-val">0</span>
+      </label>
+      <label>Líneas por bloque:
+        <input type="number" name="lineas" value="200" min="1" id="lineas">
+      </label>
+      <label class="toggle">
+        <input type="checkbox" id="sin-bloques"> Procesar capítulo completo
+      </label>
+        <label>Pausa entre bloques (s):
+          <input type="number" step="0.1" name="pausa" value="1">
+        </label>
+        <button type="submit" class="btn">Convertir</button>
+      </form>
+      <footer class="version">v{{ version }}</footer>
+      <div id="progress-container" class="hidden">
+        <div id="progress-bar"></div>
+      </div>
+    </div>
+    <div id="log-panel" class="log-panel"></div>
   </div>
   <script>
   const form = document.getElementById('convert-form');
+  const fileInput = document.getElementById('archivo');
+  const nombreInput = document.getElementById('nombre');
+    const pitch = document.getElementById('pitch');
+    const pitchVal = document.getElementById('pitch-val');
+    pitch.addEventListener('input', ()=>{ pitchVal.textContent = pitch.value; });
+  const lineasInput = document.getElementById('lineas');
+  const sinBloques = document.getElementById('sin-bloques');
+  sinBloques.addEventListener('change', ()=>{
+    lineasInput.disabled = sinBloques.checked;
+    if(sinBloques.checked){ lineasInput.value = 0; }
+  });
+  fileInput.addEventListener('change', ()=>{
+    const name = fileInput.files[0]?.name.replace(/\.[^/.]+$/, '') || '';
+    nombreInput.value = name;
+  });
+
   form.addEventListener('submit', async (e)=>{
     e.preventDefault();
     const data = new FormData(form);
-    const file = form.querySelector('input[type=file]').files[0];
+    const file = fileInput.files[0];
     const est = Math.max(5, file.size / 50000); // segundos estimados
     const bar = document.getElementById('progress-bar');
     const container = document.getElementById('progress-container');
@@ -57,6 +98,15 @@
     document.write(html);
     document.close();
   });
+
+  const logPanel = document.getElementById('log-panel');
+  const evtSource = new EventSource('/logs');
+  evtSource.onmessage = (e) => {
+    const p = document.createElement('p');
+    p.textContent = e.data;
+    logPanel.appendChild(p);
+    logPanel.scrollTop = logPanel.scrollHeight;
+  };
   </script>
 </body>
 </html>

--- a/tts.py
+++ b/tts.py
@@ -3,13 +3,16 @@ import os
 import re
 from typing import List, Tuple
 
+__version__ = "1.4.0"
+
 import edge_tts
 from docx import Document
 from pydub import AudioSegment
-import textract
 
-CHUNK_LINES = 200
-CHUNK_DELAY = 1
+
+DEFAULT_CHUNK_LINES = 200
+# Pausa por defecto entre peticiones para no saturar los servidores
+DEFAULT_CHUNK_DELAY = float(os.getenv("REQUEST_PAUSE", "1"))
 
 
 def read_txt(path: str) -> str:
@@ -20,11 +23,6 @@ def read_txt(path: str) -> str:
 def read_docx(path: str) -> str:
     doc = Document(path)
     return "\n".join(p.text for p in doc.paragraphs)
-
-
-def read_doc(path: str) -> str:
-    text = textract.process(path)
-    return text.decode("utf-8")
 
 
 def split_into_chapters(text: str) -> List[Tuple[str, str]]:
@@ -41,29 +39,87 @@ def split_into_chapters(text: str) -> List[Tuple[str, str]]:
     return chapters
 
 
-async def synthesize(text: str, voice: str, rate: str, output_path: str) -> None:
-    lines = text.splitlines()
-    chunks = ["\n".join(lines[i : i + CHUNK_LINES]) for i in range(0, len(lines), CHUNK_LINES)]
+async def synthesize(
+    text: str,
+    voice: str,
+    rate: str,
+    output_path: str,
+    chunk_lines: int = DEFAULT_CHUNK_LINES,
+    chunk_delay: float = DEFAULT_CHUNK_DELAY,
+    pitch: str = "+0Hz",
+    log_callback=None,
+) -> None:
+    if chunk_lines <= 0:
+        chunks = [text]
+    else:
+        lines = text.splitlines()
+        chunks = [
+            "\n".join(lines[i : i + chunk_lines])
+            for i in range(0, len(lines), chunk_lines)
+        ]
     temp_files = []
     for idx, chunk in enumerate(chunks):
-        communicate = edge_tts.Communicate(chunk, voice=voice, rate=rate)
+        if not chunk.strip():
+            continue
+        communicate = edge_tts.Communicate(chunk, voice=voice, rate=rate, pitch=pitch)
         tmp_file = f"{output_path}_tmp_{idx}.mp3"
         await communicate.save(tmp_file)
         temp_files.append(tmp_file)
-        await asyncio.sleep(CHUNK_DELAY)
+        if chunk_delay > 0:
+            if log_callback:
+                remaining = int(chunk_delay)
+                while remaining > 0:
+                    log_callback(f"Reanudando en {remaining}s")
+                    await asyncio.sleep(1)
+                    remaining -= 1
+                remainder = chunk_delay - int(chunk_delay)
+                if remainder > 0:
+                    await asyncio.sleep(remainder)
+            else:
+                await asyncio.sleep(chunk_delay)
     audio = AudioSegment.empty()
     for f in temp_files:
-        audio += AudioSegment.from_file(f)
-        os.remove(f)
+        if os.path.exists(f):
+            audio += AudioSegment.from_file(f)
+            os.remove(f)
+        elif log_callback:
+            log_callback(f"Segmento perdido: {f}")
     audio.export(output_path, format="mp3")
 
 
-async def synthesize_book(text: str, voice: str, rate: str, out_dir: str, book_name: str) -> List[str]:
+async def synthesize_book(
+    text: str,
+    voice: str,
+    rate: str,
+    out_dir: str,
+    book_name: str,
+    chunk_lines: int = DEFAULT_CHUNK_LINES,
+    chunk_delay: float = DEFAULT_CHUNK_DELAY,
+    pitch: str = "+0Hz",
+    log_callback=None,
+) -> List[str]:
     os.makedirs(out_dir, exist_ok=True)
     chapters = split_into_chapters(text)
     files = []
+    if log_callback:
+        log_callback(f"Capítulos detectados: {len(chapters)}")
     for i, (_, chapter_text) in enumerate(chapters, start=1):
+        if log_callback:
+            log_callback(f"Procesando capítulo {i}")
         filename = os.path.join(out_dir, f"{book_name}_capitulo_{i}.mp3")
-        await synthesize(chapter_text, voice, rate, filename)
+        await synthesize(
+            chapter_text,
+            voice,
+            rate,
+            filename,
+            chunk_lines=chunk_lines,
+            chunk_delay=chunk_delay,
+            pitch=pitch,
+            log_callback=log_callback,
+        )
         files.append(filename)
+        if log_callback:
+            log_callback(f"Capítulo {i} listo")
+    if log_callback:
+        log_callback("Conversión finalizada")
     return files


### PR DESCRIPTION
## Summary
- support processing chapters in a single chunk via UI checkbox
- show countdown during configured pauses and skip empty segments to avoid missing files
- document countdown behavior and bump version to 1.4.0

## Testing
- `python -m py_compile app.py tts.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask>=2.2)*

------
https://chatgpt.com/codex/tasks/task_e_689b9e527bc08326a64fa826181cb5eb